### PR TITLE
include #string for memset

### DIFF
--- a/src/ptrwrap.h
+++ b/src/ptrwrap.h
@@ -14,6 +14,7 @@
 
 #include <node.h>
 #include <v8.h>
+#include <string.h>
 
 
 /**


### PR DESCRIPTION
This was breaking on install, so just thought I'd help a little.
